### PR TITLE
fix: do not load ollama.yml when not neeeded

### DIFF
--- a/lib/ex_llm/providers/ollama.ex
+++ b/lib/ex_llm/providers/ollama.ex
@@ -88,9 +88,9 @@ defmodule ExLLM.Providers.Ollama do
 
     config = get_config(config_provider)
 
-    raw_model = Keyword.get(options, :model, Map.get(config, :model, get_default_model()))
+    raw_model = Keyword.get(options, :model, Map.get(config, :model))
     # Strip provider prefix if present
-    model = strip_provider_prefix(raw_model)
+    model = strip_provider_prefix(raw_model || get_default_model())
 
     # Ensure we have a model
     model = model || get_default_model()
@@ -157,9 +157,9 @@ defmodule ExLLM.Providers.Ollama do
 
     config = get_config(config_provider)
 
-    raw_model = Keyword.get(options, :model, Map.get(config, :model, get_default_model()))
+    raw_model = Keyword.get(options, :model, Map.get(config, :model))
     # Strip provider prefix if present
-    model = strip_provider_prefix(raw_model)
+    model = strip_provider_prefix(raw_model || get_default_model())
 
     # Ensure we have a model
     model = model || get_default_model()


### PR DESCRIPTION
Doing local inference with Ollama required an existing `config/models/ollama.yml` without this change.